### PR TITLE
fix : 타이머 알림 모바일 / pc 환경 분리

### DIFF
--- a/src/components/Timer/Notification.tsx
+++ b/src/components/Timer/Notification.tsx
@@ -1,18 +1,14 @@
-export const triggerNotification = async (setPopupMessage: (msg: string | null) => void) => {
-  if (Notification.permission === "granted") {
+export const triggerNotification = async (): Promise<"popup" | "push"> => {
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  if (!isMobile && Notification.permission === "granted") {
     new Notification("타이머 종료", {
       body: "타이머가 종료되었습니다!",
       icon: "/images/mainLogo.svg"
     });
-    setPopupMessage("타이머가 종료되었습니다!");
-  } else if (Notification.permission === "default") {
-    const permission = await Notification.requestPermission();
-    if (permission === "granted") {
-      new Notification("타이머 종료", {
-        body: "타이머가 종료되었습니다!"
-      });
-      setPopupMessage("타이머가 종료되었습니다!");
-    }
+    return "push"; // 푸쉬 알림이 성공한 경우
+  } else {
+    return "popup"; // 토스트 알림이 필요한 경우
   }
 };
 

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -41,7 +41,11 @@ const Timer: React.FC = memo(() => {
     } else if (timeLeft <= 0 && isRunning) {
       clearInterval(timer!);
       setIsRunning(false);
-      triggerNotification(setPopupMessage);
+      triggerNotification().then((type) => {
+        if (type === "popup") {
+          setPopupMessage("타이머가 종료되었습니다!");
+        }
+      });
       playSound();
     }
 


### PR DESCRIPTION
## 💁🏻‍♀️ 작업

- 타이머 알림 모바일 / pc 환경 분리

<br>

## 🔥 작업 세부 내용

- 작업1: 타이머 종료 시 브라우저에서는 notification api 푸시알림, 모바일에서는 일반 알림창으로 수정하였습니다.
- 작업2: 웹 브라우저에서 화면 크기 조율 후 테스트 시에는 문제 없었습니다.

<br>

## 🚫 참고 사항

- 메인 병합 후 모바일, 웹 둘다 이상 없는지 체크 필요해요!
