### PR TITLE
fix : 레시피카드2 콘솔에러 삭제, 유저닉네임 가져오는 로직 변경

### DIFF
--- a/src/components/myrecipedetail/RecipeCard2.tsx
+++ b/src/components/myrecipedetail/RecipeCard2.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { getUserNickname } from "@/serverActions/profileAction";
+import { useUserNickname } from "@/serverActions/profileAction";
 import Image from "next/image";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import FireFilledIcon from "@images/fireFilled.svg";
 import FireEmptyIcon from "@images/fireEmpty.svg";
 import browserClient from "@/supabase/client";
@@ -22,16 +22,11 @@ interface ExtendedRecipeCardProps extends RecipeCardProps {
 
 const RecipeCard2 = ({ post, isEditMode = false, onDelete }: ExtendedRecipeCardProps) => {
   const { userId } = useStore(useAuthStore);
-  const [nickname, setNickname] = useState("");
+  const { data: nickname } = useUserNickname(post.user_id);
   const router = useRouter();
 
   useEffect(() => {
-    const fetchUserProfile = async () => {
-      if (post.user_id) {
-        const userProfile = await getUserNickname(post.user_id);
-        setNickname(userProfile);
-      }
-    };
+    if (!userId) return;
     const fetchIsUserLiked = async () => {
       const { error } = await browserClient
         .from("LIKE_TABLE")
@@ -42,10 +37,9 @@ const RecipeCard2 = ({ post, isEditMode = false, onDelete }: ExtendedRecipeCardP
         throw error;
       }
     };
-    fetchUserProfile();
     fetchIsUserLiked();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [userId]);
 
   return (
     <div


### PR DESCRIPTION
## 💁🏻‍♀️ 작업
- 유저 닉네임 가져오는 로직을 profileAction에서 따로 만들어둔 함수로 수정
- userId 전역상태 값을 가져오기 전에 fetchIsUserLiked가 실행될 경우 return되서 콘솔에 에러가 나지 않도록 수정
